### PR TITLE
Set build-id to none

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,11 +10,11 @@ add_library(lodepng_flutter SHARED
   "lodepng.h"
 )
 
+add_link_options("-Wl,--build-id=none")
+
 set_target_properties(lodepng_flutter PROPERTIES
   PUBLIC_HEADER lodepng.h
   OUTPUT_NAME "lodepng_flutter"
 )
 
 target_compile_definitions(lodepng_flutter PUBLIC DART_SHARED_LIB)
-
-add_link_options("-Wl,--build-id=none")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,3 +16,5 @@ set_target_properties(lodepng_flutter PROPERTIES
 )
 
 target_compile_definitions(lodepng_flutter PUBLIC DART_SHARED_LIB)
+
+add_link_options("-Wl,--build-id=none")


### PR DESCRIPTION
Disable [ndk build id](https://f-droid.org/docs/Reproducible_Builds/#ndk-build-id) to fix Reproducible Builds of venera. No side effect it seems.